### PR TITLE
[FIX] CD target github url 과 github branch 변경

### DIFF
--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -2,14 +2,13 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: CI
+permissions: write-all
 
 on:
   push:
     branches: ['main']
   pull_request:
     branches: ['main']
-
-permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: transferwise/actions-next-bundle-analyzer@v2
         with:
           comment-strategy: 'always'
+          create-issue: false
       - name: Delete merged branch
         uses: SvanBoxel/delete-merged-branch@1.4.3
         with:

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches: ['main']
 
-permissions: write-all
+permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -9,8 +9,7 @@ on:
   pull_request:
     branches: ['main']
 
-permissions:
-    actions: "write"
+permissions: write-all
 
 jobs:
   build:

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -10,8 +10,7 @@ on:
     branches: ['main']
 
 permissions:
-    actions: write
-    deployments: write
+    actions: "write"
 
 jobs:
   build:

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -9,10 +9,12 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+    actions: write
+    deployments: write
+
 jobs:
   build:
-    permissions:
-      actions: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -6,12 +6,11 @@ name: CI
 on:
   push:
     branches: ['main']
-  pull_request:
+  pull_request_target:
     branches: ['main']
 
 jobs:
   build:
-    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -2,7 +2,6 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: CI
-permissions: write-all
 
 on:
   push:
@@ -12,6 +11,7 @@ on:
 
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/customCI.yaml
+++ b/.github/workflows/customCI.yaml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   build:
-    permissions: write-all
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         
         stage('github_clone') {
             steps {
-                git branch: 'dev/ci-cd', credentialsId: 'github_token', url: 'https://github.com/falconlee236/PuangFilm-FE-local'
+                git branch: 'main', credentialsId: 'github_token', url: 'https://github.com/GDSC-CAU/PuangFilm-FE'
             }
         }
 


### PR DESCRIPTION
## Summary

* 기존에 Jenkins파일에서 git clone을 할 대상이 local 레포였는데, 실제 repo로 변경합니다.
* github action 중에서 쓰기 권한이 없어서 생긴 문제를 해결합니다.

## Description
* Jenkinsfile의 git clone target을 변경합니다.
* github action에 yml 파일에 쓰기 권한을 줍니다.